### PR TITLE
Add returnTo property to logout()

### DIFF
--- a/10.2 Final Deploy Configurations in Netlify/src/components/Navbar.js
+++ b/10.2 Final Deploy Configurations in Netlify/src/components/Navbar.js
@@ -35,7 +35,9 @@ export default function Navbar({ toggleTheme }) {
                 )}
                 {isAuthenticated && (
                     <li>
-                        <StyledButtonLink onClick={logout}>
+                        <StyledButtonLink onClick={
+                            () => logout({ returnTo: window.location.origin })
+                        }>
                             Logout
                         </StyledButtonLink>
                     </li>


### PR DESCRIPTION
Looks like if you don't add a `returnTo` property to `logout()` from `useAuth0()` hook, it redirect you to the first url on "Allowed Logout URLs" list. In this case, its redirecting to http://localhost:8888 after logout on both, local dev environment and also on deployed netlify ver.