### PR TITLE
fix: scorer name not recorded if login with Auth0

### DIFF
--- a/10.2 Final Deploy Configurations in Netlify/src/pages/GameOver.js
+++ b/10.2 Final Deploy Configurations in Netlify/src/pages/GameOver.js
@@ -7,7 +7,7 @@ import { useAuth0 } from '../auth';
 export default function GameOver({ history }) {
     const [score] = useScore();
     const [scoreMessage, setScoreMessage] = useState('');
-    const { isAuthenticated, getTokenSilently } = useAuth0();
+    const { isAuthenticated, getTokenSilently, user } = useAuth0();
     if (score === -1) {
         history.push('/');
     }
@@ -19,7 +19,7 @@ export default function GameOver({ history }) {
                 const options = {
                     method: 'POST',
                     body: JSON.stringify({
-                        name: 'asdasfsd',
+                        name: user?.nickname ?? user?.name,
                         score,
                     }),
                     headers: {


### PR DESCRIPTION
Just a quick update, as we add `user` from Auth0, we can access user.name or user.nickname to give a more meaningful high score table.